### PR TITLE
WIZ-11443 Fix TestRunner inheritance problem

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,8 +2,8 @@
     "name": "wizaplace/phpunit-slicer",
     "license": "MIT",
     "require": {
-        "php": "^7.1",
-        "phpunit/phpunit": "^7|^8"
+        "php": "^7.1|^8.0",
+        "phpunit/phpunit": "^7|^8|^9"
     },
     "autoload": {
         "psr-4": {

--- a/src/Command.php
+++ b/src/Command.php
@@ -51,7 +51,7 @@ Slices Options:
 EOT;
     }
 
-    protected function createRunner(): \PHPUnit\TextUI\TestRunner
+    protected function createRunner(): TestRunner
     {
         return new TestRunner($this->arguments['loader']);
     }

--- a/src/TestRunner.php
+++ b/src/TestRunner.php
@@ -7,18 +7,25 @@ namespace Wizaplace\PHPUnit\Slicer;
 use PHPUnit\Framework\Test;
 use PHPUnit\Framework\TestResult;
 use PHPUnit\Framework\TestSuite;
+use PHPUnit\Runner\TestSuiteLoader;
+use PHPUnit\TextUI\TestRunner as PhpUnitTestRunner;
 
-class TestRunner extends \PHPUnit\TextUI\TestRunner
+class TestRunner
 {
+    /* @var PhpUnitTestRunner */
+    private $phpUnitTestRunner;
+
+    public function __construct(TestSuiteLoader $loader)
+    {
+        $this->phpUnitTestRunner = new PhpUnitTestRunner($loader);
+    }
+
     public function doRun(Test $suite, array $arguments = [], $exit = true): TestResult
     {
         if (isset($arguments['totalSlices'], $arguments['currentSlice']) && $suite instanceof TestSuite) {
-            $localArguments = $arguments;
-            $this->handleConfiguration($localArguments);
-
-            TestSuiteSlicer::slice($suite, $localArguments);
+            TestSuiteSlicer::slice($suite, $arguments);
         }
 
-        return parent::doRun($suite, $arguments, $exit);
+        return $this->phpUnitTestRunner->doRun($suite, $arguments, $exit);
     }
 }


### PR DESCRIPTION
Due to incompatibility with phpunit > 7

Test to change TestRunner inheritance to composition.
For now it style doesn't work : 
```
PHP Fatal error:  Declaration of Wizaplace\PHPUnit\Slicer\Command::createRunner(): Wizaplace\PHPUnit\Slicer\TestRunner must be compatible with PHPUnit\TextUI\Command::createRunner(): PHPUnit\TextUI\TestRunner in /var/www/vendor/wizaplace/phpunit-slicer/src/Command.php on line 54
```


Additionals composer changes :
Add phpunit9 compatibility
Add php8 compatibility